### PR TITLE
Fixes #4 Crash on simultaneous erase and move of marker

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,5 +1,7 @@
 **/.vs
+**/Debug
 **/Release
 **/private
 **/Public
 **/*.aps
+**/*.sbr

--- a/src/DDraw/ElementHandler.cpp
+++ b/src/DDraw/ElementHandler.cpp
@@ -30,6 +30,7 @@ CElementHandler::~CElementHandler()
 					//delete Curt_GElemPtr;
 					delete (*iter);
 					iter = map[y][x].erase ( iter);
+                    allElements.erase(*iter);
 				}
 				//Curt_GElemPtr= map[y][x].back();
 				//delete ;
@@ -59,6 +60,12 @@ void CElementHandler::AddElement(GraphicElement *ge)
 	int y=(ge->y1>>HASH_SQUARE_SIZE) & (ELEMENT_HASH_SIZE-1);
 
 	map[y][x].push_back(ge);
+    allElements.insert(ge);
+}
+
+bool CElementHandler::IsElement(GraphicElement* ge)
+{
+    return ge && (allElements.count(ge) > 0);
 }
 
 void CElementHandler::DeleteOn(int x, int y)
@@ -95,6 +102,7 @@ void CElementHandler::DeleteBetween(int x1, int y1, int x2, int y2)
 			while(!toBeDeleted.empty()){
 				delete toBeDeleted.back();
 				map[y][x].remove(toBeDeleted.back());
+                allElements.erase(toBeDeleted.back());
 				toBeDeleted.pop_back();
 			}
 		}
@@ -184,18 +192,19 @@ GraphicElement* CElementHandler::GetClosestElement(int x, int y)
 
 GraphicElement* CElementHandler::MoveTextElement(GraphicElement* GE, int x, int y)
 {
-
 	try
 	{
 		//add a new identical element then remove the old
-		GraphicText *ge = (GraphicText*)GE;
+        GraphicText *ge = (GraphicText*)GE;
 		GraphicText *Nge = new GraphicText(x, y, ge->text, ge->Color);
 
 		int mx=(ge->x1>>HASH_SQUARE_SIZE) & (ELEMENT_HASH_SIZE-1);
 		int my=(ge->y1>>HASH_SQUARE_SIZE) & (ELEMENT_HASH_SIZE-1);
 		map[my][mx].remove(ge);
-		if(ge)
-			delete ge;
+        allElements.erase(ge);
+        if (ge) {
+            delete ge;
+        }
 
 		AddElement(Nge);
 

--- a/src/DDraw/ElementHandler.h
+++ b/src/DDraw/ElementHandler.h
@@ -10,6 +10,7 @@
 #endif // _MSC_VER > 1000
 
 #include <list>
+#include <set>
 #include <vector>
 
 #define ClassGraphicLine 1
@@ -52,9 +53,10 @@ public:
 	GraphicText(int x,int y,char* intext,char cC)
 		:GraphicElement(x,y,ClassGraphicText,cC)
 		{
-			size_t temp_Size= strlen(intext)+1;
+			size_t temp_Size= strnlen(intext, 16)+1;
 			text=new char[temp_Size];
-			strcpy_s(text,temp_Size, intext);
+            memcpy(text, intext, temp_Size);
+            text[temp_Size - 1] = 0;
 		}
 	void virtual Draw() {};
 	char* text;
@@ -102,7 +104,8 @@ public:
 	void DeleteBetween(int x1,int y1,int x2,int y2);
 	void DeleteOn(int x,int y);
 	void AddElement(GraphicElement* ge);
-   GraphicElement* MoveTextElement(GraphicElement* GE, int x, int y); 
+    bool IsElement(GraphicElement* ge);
+    GraphicElement* MoveTextElement(GraphicElement* GE, int x, int y);
 	CElementHandler();
 	virtual ~CElementHandler();
 
@@ -110,6 +113,7 @@ private:
 	typedef std::list<GraphicElement*> ElementList;
 
 	ElementList map[ELEMENT_HASH_SIZE][ELEMENT_HASH_SIZE];
+    std::set<GraphicElement*> allElements;
 };
 
 #endif // !defined(AFX_ELEMENTHANDLER_H__7B55B501_0A7A_11D5_AD55_0080ADA84DE3__INCLUDED_)

--- a/src/DDraw/iddraw.cpp
+++ b/src/DDraw/iddraw.cpp
@@ -4,6 +4,7 @@
 #include "iddraw.h"           
 #include "iddrawsurface.h"
 #include <stdio.h>
+#include <string>
 //---------------------------------------------------------------------------
 //#pragma package(smart_init)
 
@@ -165,12 +166,18 @@ HRESULT __stdcall IDDraw::RestoreDisplayMode()
 HRESULT __stdcall IDDraw::SetCooperativeLevel(HWND arg1, DWORD arg2)
 {
 	OutptTxt("SetCooperativeLevel");
-	if(Windowed == false)
-		return lpDD->SetCooperativeLevel(arg1, arg2);
-	else
-	{
-		return lpDD->SetCooperativeLevel(arg1, DDSCL_NORMAL);
-	}
+    if (arg1) {
+        LocalShare->GuiThreadId = GetWindowThreadProcessId(arg1, NULL);
+        std::string log = "SetCooperativeLevel, GUI theadid = " + std::to_string(LocalShare->GuiThreadId);
+        OutptTxt(log.c_str());
+    }
+
+    if (Windowed == false) {
+        return lpDD->SetCooperativeLevel(arg1, arg2);
+    }
+    else {
+        return lpDD->SetCooperativeLevel(arg1, DDSCL_NORMAL);
+    }
 }
 
 HRESULT __stdcall IDDraw::SetDisplayMode(DWORD arg1, DWORD arg2,DWORD arg3)

--- a/src/DDraw/iddraw.h
+++ b/src/DDraw/iddraw.h
@@ -6,7 +6,6 @@
 
 #define DDRAW_INIT_STRUCT(ddstruct) { memset(&ddstruct,0,sizeof(ddstruct)); ddstruct.dwSize=sizeof(ddstruct); }
 
-extern bool Log;
 //---------------------------------------------------------------------------
 //public TComInterface<IDirectDraw>, public TComInterfaceBase<IUnknown>
 class IDDraw : public IDirectDraw

--- a/src/DDraw/iddrawsurface.cpp
+++ b/src/DDraw/iddrawsurface.cpp
@@ -738,11 +738,9 @@ HRESULT __stdcall IDDrawSurface::UpdateOverlayZOrder(DWORD arg1, LPDIRECTDRAWSUR
 void IDDrawSurface::OutptTxt(char *string)
 {
 #ifdef DEBUG_INFO
-	if(!Log)
-		return;
 	//AnsiString CPath = "c:\\taddrawlog.txt";
 
-	HANDLE file = CreateFileA("C:\\taddrawlog.txt", GENERIC_WRITE, 0, NULL, OPEN_ALWAYS	, 0, NULL);
+	HANDLE file = CreateFileA("C:\\temp\\taddrawlog.txt", GENERIC_WRITE, 0, NULL, OPEN_ALWAYS	, 0, NULL);
 	DWORD tempWritten;
 	SetFilePointer ( file, 0, 0, FILE_END);
 	WriteFile ( file, string, strlen(string), &tempWritten, NULL);

--- a/src/DDraw/iddrawsurface.h
+++ b/src/DDraw/iddrawsurface.h
@@ -110,10 +110,13 @@ typedef struct LocalShare_
 
 	UINT LocalPlayerID;
 	UINT OrgLocalPlayerID;
+    DWORD GuiThreadId;
 
 	LPSTR ModRegName;
 	//extern for unicode font;
 	//LPVOID TAUnicodeSupport;
+
+    LocalShare_() : GuiThreadId(0) {}
 }*LocalSharePTR;
 extern LocalShare_* LocalShare;
 
@@ -162,7 +165,7 @@ public:
 	void CreateDir(char *Dir);
 	void CorrectName(char *Name);
 
-	static void OutptTxt(char *string);
+	static void OutptTxt(const char *string);
 	static void OutptInt(int Int_I);
 	void Set(bool EnableVSync);
 	void FrontSurface (LPDIRECTDRAWSURFACE lpTASurf);

--- a/src/DDraw/iddrawsurface.h
+++ b/src/DDraw/iddrawsurface.h
@@ -2,6 +2,8 @@
 #ifndef iddrawsurfaceH
 #define iddrawsurfaceH
 
+#include <ddraw.h>
+
 // shall to reduce internation between class
 //class ExternQuickKey;
 //---------------------------------------------------------------------------
@@ -115,7 +117,6 @@ typedef struct LocalShare_
 }*LocalSharePTR;
 extern LocalShare_* LocalShare;
 
-extern bool Log;
 extern HINSTANCE HInstance;
 
 LRESULT CALLBACK WinProc(HWND winprocwnd, UINT msg, WPARAM wparam, LPARAM lparam);

--- a/src/DDraw/whiteboard.cpp
+++ b/src/DDraw/whiteboard.cpp
@@ -253,7 +253,7 @@ bool AlliesWhiteboard::Message(HWND WinProcWnd, UINT Msg, WPARAM wParam, LPARAM 
 					Rtn_Bool= true;
 					break;
 				}
-				else if(CurrentElement)
+				else if(ElementHandler.IsElement(CurrentElement))
 				{
 					Move = true;
 					Rtn_Bool= true;
@@ -279,7 +279,7 @@ bool AlliesWhiteboard::Message(HWND WinProcWnd, UINT Msg, WPARAM wParam, LPARAM 
 		{
 			IDDrawSurface::OutptTxt ( "Get Mark Text");
 			CurrentElement = GetTextElementAt(*MapX+LOWORD(lParam)-128, *MapY+HIWORD(lParam)-32, 5);
-			if(CurrentElement)
+			if(ElementHandler.IsElement(CurrentElement))
 				lstrcpyA(Text, ((GraphicText*)CurrentElement)->text);
 
 			InputShown = true;
@@ -330,7 +330,7 @@ bool AlliesWhiteboard::Message(HWND WinProcWnd, UINT Msg, WPARAM wParam, LPARAM 
 		break;
 
 	case WM_RBUTTONUP:
-		if(WBKeyDown)
+        if(WBKeyDown)
 		{
 			Rtn_Bool= true;
 			break;
@@ -372,7 +372,7 @@ bool AlliesWhiteboard::Message(HWND WinProcWnd, UINT Msg, WPARAM wParam, LPARAM 
 			}
 			if(Move)
 			{
-				if(CurrentElement)
+				if(ElementHandler.IsElement(CurrentElement))
 				{
 					PacketHandler.push_back(new GraphicMoveText(CurrentElement->x1, CurrentElement->y1, *MapX+LOWORD(lParam)-128, *MapY+HIWORD(lParam)-32, *PlayerColor));
 					CurrentElement = ElementHandler.MoveTextElement(CurrentElement, *MapX+LOWORD(lParam)-128, *MapY+HIWORD(lParam)-32);
@@ -414,7 +414,7 @@ void AlliesWhiteboard::DrawTextInput(LPDIRECTDRAWSURFACE DestSurf)
 	int BFHalfX = (LocalShare->ScreenWidth-128)/2 + 128;
 	int BFHalfY = (LocalShare->ScreenHeight-64)/2 + 32;
 
-	if(CurrentElement)
+	if(ElementHandler.IsElement(CurrentElement))
 		DialogPTR->DrawText(DestSurf, BFHalfX-InputBoxWidth/2+5, BFHalfY-InputBoxHeight/2-13, "Edit Textmarker");
 	else
 		DialogPTR->DrawText(DestSurf, BFHalfX-InputBoxWidth/2+5, BFHalfY-InputBoxHeight/2-13, "Add Textmarker");
@@ -448,7 +448,7 @@ void AlliesWhiteboard::TextInputKeyDown(int Key)
 	switch(Key)
 	{
 	case 13: //enter
-		if(CurrentElement)
+		if(ElementHandler.IsElement(CurrentElement))
 		{
 			if (NULL!=((GraphicText*)CurrentElement)->text)
 			{
@@ -740,7 +740,7 @@ void AlliesWhiteboard::ReceiveMarkers()
 			Data += sizeof(Pts);
 
 			GraphicText *GT = (GraphicText*)GetTextElementAt(pts->x, pts->y, 1);
-			if(GT)
+			if(ElementHandler.IsElement(GT))
 			{
 				delete GT->text;
 				GT->text = new char[strlen(Data)+1];
@@ -751,8 +751,9 @@ void AlliesWhiteboard::ReceiveMarkers()
 		{
 			PtL *ptl = (PtL*)Data;
 			GraphicText *GT = (GraphicText*)GetTextElementAt(ptl->x, ptl->y, 1);
-			if(GT)
-				GT = (GraphicText*)ElementHandler.MoveTextElement(GT, ptl->x2, ptl->y2);
+            if (ElementHandler.IsElement(GT)) {
+                GT = (GraphicText*)ElementHandler.MoveTextElement(GT, ptl->x2, ptl->y2);
+            }
 			Data += sizeof(PtL);
 		}
 		else //unknown type skip packet

--- a/src/DDraw/whiteboard.cpp
+++ b/src/DDraw/whiteboard.cpp
@@ -554,8 +554,8 @@ void AlliesWhiteboard::DrawMarkers(LPDIRECTDRAWSURFACE DestSurf)
 
 void AlliesWhiteboard::DrawMinimapMarkers(char *VidBuf, int Pitch, bool Receive)
 {
-	if(Receive)
-		ReceiveMarkers();
+    if (Receive)
+        ReceiveMarkers();
 
 	if(MinimapMarkerHandler.empty())
 		return;
@@ -685,8 +685,11 @@ void AlliesWhiteboard::MouseMove(int XStart, int XEnd, int YStart, int YEnd)
 
 void AlliesWhiteboard::ReceiveMarkers()
 {
-	if(DataShare->FromAlliesLength==0)
-		return;
+    if (LocalShare->GuiThreadId != GetCurrentThreadId())
+        return;
+
+    if (DataShare->FromAlliesLength == 0)
+        return;
 
 	char *NumPackets = DataShare->FromAllies;
 	char *Data = DataShare->FromAllies + 1;
@@ -768,8 +771,11 @@ void AlliesWhiteboard::ReceiveMarkers()
 
 void AlliesWhiteboard::SendMarkers()
 {
-	if(DataShare->ToAlliesLength>0 || PacketHandler.empty())
-		return;
+    if (LocalShare->GuiThreadId != GetCurrentThreadId())
+        return;
+
+    if (DataShare->ToAlliesLength > 0 || PacketHandler.empty())
+        return;
 
 	char *NumPackets = DataShare->ToAllies;
 	char *Data = DataShare->ToAllies + 1;


### PR DESCRIPTION
Maintain a set of all graphic elements so they can be tested whether or not they still exist.
Guard against corrupted GraphicText by limiting length of marker text.

Should be effective at preventing crashes in multiplayer marker move too.
[tdraw.zip](https://github.com/Axle1975/TADR/files/12640664/tdraw.zip)

fixes #4 
